### PR TITLE
Fix returning logprobs for async engine generation

### DIFF
--- a/python/sglang/srt/two_batch_overlap.py
+++ b/python/sglang/srt/two_batch_overlap.py
@@ -460,6 +460,7 @@ class TboForwardBatchPreparer:
             "extend_seq_lens_cpu",
             "extend_logprob_start_lens_cpu",
             "lora_paths",
+            "extend_input_logprob_token_gpu",
         ]:
             old_value = getattr(batch, key)
             if old_value is None:
@@ -471,6 +472,7 @@ class TboForwardBatchPreparer:
                 or key == "extend_prefix_lens_cpu"
                 or key == "extend_seq_lens_cpu"
                 or key == "extend_logprob_start_lens_cpu"
+                or key == "extend_input_logprob_token_gpu"
             ):
                 output_dict[key] = None
                 continue


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Currently trying to run `sgl.Engine(...).async_generate(return_logprob=True` for Deepseek R1 with two batch overlap enabled we're getting the error :
```
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/forward_batch_info.py", line 411, in init_new
    TboForwardBatchPreparer.prepare(                                                                                                                                                                                                                                                                    File "/sgl-workspace/sglang/python/sglang/srt/two_batch_overlap.py", line 370, in prepare
    cls.prepare_raw(                                                                                                                                                                                                                                                                                    File "/sgl-workspace/sglang/python/sglang/srt/two_batch_overlap.py", line 399, in prepare_raw                                                                                                                                                                                                           child_a = cls.filter_batch(
              ^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                         File "/sgl-workspace/sglang/python/sglang/srt/two_batch_overlap.py", line 566, in filter_batch
    raise Exception(f"{len(errors)} errors happen:\n" + "\n\n".join(errors))                                                                                                                                                                                                                          Exception: 1 errors happen:
Field extend_input_logprob_token_ids_gpu has value, but is not yet supported (value=tensor([0], device='cuda:0') batch=ForwardBatch(forward_mode=<ForwardMode.DECODE: 2>, batc
```

## Modifications

Added the missing parameter to the ones accepted by the function

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
